### PR TITLE
Improve home screen section layout for desktop and mobile

### DIFF
--- a/components/FeaturedArticles.tsx
+++ b/components/FeaturedArticles.tsx
@@ -12,18 +12,15 @@ import Link from "next/link";
 
    return (
      <div className="featureArticles">
-      <div className="featureArticles_item">   
-      <h2 className="centerTitle" {...storyblokEditable(blok)}><span className={styles.gradient}>{blok.name}</span></h2>
-      <div className={styles.itemGrid}>
-      {featuredItems}
+      <div className="featureArticles_item">
+        <h2 className="centerTitle" {...storyblokEditable(blok)}><span className={styles.gradient}>{blok.name}</span></h2>
+        <div className={styles.itemGrid}>
+          {featuredItems}
+        </div>
+        <div className={styles.seeMoreButton}>
+          <Link href={blok.url}><button>View more</button></Link>
+        </div>
       </div>
-      <div className={styles.seeMoreButton} > 
-      <Link href={blok.url}><button>
-            View more
-        </button></Link>
-      </div>
-      </div>
-
      </div>
    );
  };

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -177,23 +177,29 @@
 }
 .itemGrid {
 	display: grid;
-	grid-template-columns: 1fr 1fr 1fr;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 0.5rem;
+	padding: 0 1rem;
 	@include media('<=tablet'){
+		grid-template-columns: repeat(2, 1fr);
+	}
+	@include media('<=phone'){
 		grid-template-columns: 1fr;
 	}
 }
 .itemGridExpand {
 	display: grid;
-	grid-template-columns: 1fr 1fr 1fr;
-	@include media('>desktop'){
-	grid-template-columns: 1fr 1fr 1fr 1fr;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 0.5rem;
+	padding: 0 1rem;
+	@include media('>phone'){
+		grid-template-columns: repeat(3, 1fr);
 	}
-	
+	@include media('>desktop'){
+		grid-template-columns: repeat(4, 1fr);
+	}
 	@include media('>=LGdesktop'){
-		grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-		}
-	@include media('<=tablet'){
-		grid-template-columns: 1fr;
+		grid-template-columns: repeat(5, 1fr);
 	}
 }
 .itemContainer {
@@ -202,8 +208,7 @@
 	height: auto;
 	pointer-events: all;
   }
-.postitem {	
-	margin: 0.5rem;
+.postitem {
 	position: relative;
 	border-radius: 7%;
 	overflow:hidden;
@@ -317,28 +322,33 @@ a:hover + .postTitle {
 }
 
 .filterNav {
-    display:flex;
+    display: flex;
     align-items: center;
     flex-direction: row;
 	justify-content: center;
 	flex-wrap: wrap;
+	gap: 0.4rem;
+	padding: 1rem 1rem 0.5rem;
     button {
-        font-size: medium;
+        font-size: 0.875rem;
+        font-family: var(--sunroll-font);
         text-decoration: none;
-        border: none;
+        border: 1px solid transparent;
         color: c.$mainColor;
         background-color: c.$mainBG;
         border-radius: 30px;
-        padding: 0.5rem 1rem;
+        padding: 0.4rem 1.1rem;
         display: block;
+        cursor: pointer;
+        transition: color 0.3s, border-color 0.3s;
     }
     button:hover {
         color: white;
-        transition: 0.7s;
+        border-color: c.$mainColor;
     }
 	@media (hover: none) {
-		cursor:'pointer'
-	  }
+		button { cursor: pointer; }
+	}
 }
 
 .closeArchive {
@@ -350,6 +360,10 @@ a:hover + .postTitle {
 	text-align: center;
 	align-items: center;
 	align-content: center;
+	max-width: 800px;
+	margin: 0.5rem auto;
+	padding: 0 1rem;
+	line-height: 1.6;
 }
 
 .articleBanner{
@@ -388,67 +402,92 @@ a:hover + .postTitle {
 
   .loadingPref {
 	font-family: var(--sunroll-font);
-	font-weight: "bold";
-	margin: 3% 10%;
-	display: grid;
+	margin: 2rem 0;
+	display: flex;
 	justify-content: center;
-	text-align: center;
-	grid-template-columns: 1fr 1fr 1fr;
+	align-items: center;
+	gap: 1rem;
+	flex-wrap: wrap;
+	p {
+		margin: 0;
+		color: c.$mainColor;
+		opacity: 0.6;
+		font-size: 0.875rem;
+	}
 	button {
 		font-family: var(--sunroll-font);
-		font-weight: "bold";
-		font-size: xx-small;
-		background-image: linear-gradient(35deg, c.$mainColor, #ac60ab, #6a60a0, #385880);	
+		background-image: linear-gradient(35deg, c.$mainColor, #ac60ab, #6a60a0, #385880);
 		animation: animate 7s ease infinite;
 		background-size: 200%;
-		-webkit-background-clip:initial;
-		-moz-background-clip:initial;
-		background-clip:initial;
+		-webkit-background-clip: initial;
+		-moz-background-clip: initial;
+		background-clip: initial;
 		border-radius: 3vmin;
-		padding: 2vmin 2vmin;
+		padding: 0.75rem 1.75rem;
 		color: white;
-		font-size: large;
-		cursor: pointer; 
+		font-size: 1rem;
+		cursor: pointer;
 	}
-	button:hover {color: rgb(26, 3, 56); transition: 0.3s ease; }
+	button:hover { color: rgb(26, 3, 56); transition: 0.3s ease; }
   }
 
 .itemList {
 	display: grid;
 	grid-template-columns: 1fr;
-	grid-template-rows: 1fr;
 	position: relative;
 	width: auto;
+	padding: 0 5%;
 }
 
 .listContainer{
 	display: grid;
 	grid-template-columns: 1fr 2fr;
-	grid-template-rows: 1fr 0.2fr;
-	overflow:hidden;
-	margin: 0 10%;
-	align-items: center;	
+	gap: 1.5rem;
+	overflow: hidden;
+	padding: 1.25rem 0;
+	align-items: center;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+	&:first-child { border-top: 1px solid rgba(255, 255, 255, 0.07); }
+	@include media('<=tablet'){
+		grid-template-columns: 1fr;
+		gap: 0.75rem;
+		padding: 1rem 0;
+	}
 }
 
 .listImage {
 	position: relative;
 	aspect-ratio: 1.2/1;
 	overflow:hidden;
+	border-radius: 8px;
 }
 
 .listText{
-	margin: 0 5%;
+	padding: 0 1rem;
+	@include media('<=tablet'){
+		padding: 0;
+	}
 }
 
 .viewPref{
-	height: 2rem;
-	margin-top: 0.5rem;
 	display: flex;
 	justify-content: center;
+	gap: 0.5rem;
+	padding: 1.5rem 1rem 0;
 	button {
 		background-color: c.$mainBG;
 		color: c.$mainColor;
-		border: none;
+		border: 1px solid c.$mainColor;
+		border-radius: 20px;
+		padding: 0.4rem 1.1rem;
+		font-family: var(--sunroll-font);
+		font-size: 0.875rem;
+		cursor: pointer;
+		transition: background-color 0.3s, color 0.3s;
+		&:hover {
+			background-color: c.$mainColor;
+			color: c.$mainBG;
+		}
 	}
 }
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -298,18 +298,23 @@ footer {
   }
 }
 
+.featureArticles {
+  padding: 4rem 0 2rem;
+  @include media('<=tablet'){
+    padding: 3rem 0 1.5rem;
+  }
+}
+
 .featureArticles_item{
-  padding: auto 0;
   width: 100%;
   @include media('<=tablet'){
     width: 90%;
     margin: auto;
   }
-  
 }
 
 .section{
-  padding-top: 10%;
+  padding: clamp(2rem, 8vw, 5rem) 0 2rem;
 }
   
 .centerTitle {


### PR DESCRIPTION
- Add gap and padding to itemGrid/itemGridExpand so cards have breathing room
- Fix itemGrid responsive breakpoints: 3-col → 2-col (tablet) → 1-col (phone)
- Fix itemGridExpand: 2→3→4→5 cols instead of jumping to 12 on LGdesktop
- List view now stacks vertically on tablet/mobile with dividers and proper gap
- filterNav gets gap, visible border on hover, and consistent font
- viewPref redesigned with pill buttons that invert on hover
- loadingPref changed from 3-col grid to flex row so "or" sits naturally between buttons
- Section padding uses clamp() instead of fixed 10% for better mobile scaling
- featureArticles wrapper gets responsive top/bottom padding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CSS/layout tweaks across home/article listing components; low risk but could cause unintended spacing/breakpoint regressions on some viewports.
> 
> **Overview**
> Tightens up the home/landing layouts by updating `itemGrid`/`itemGridExpand` to use consistent `gap`/padding and more predictable responsive column breakpoints (3→2→1 and 2→3→4→5).
> 
> Refreshes list and navigation UI styling: list view now adds padding, dividers, responsive stacking, and rounded images; `filterNav`, `viewPref`, and `loadingPref` are restyled for more consistent spacing/typography and hover behavior.
> 
> Updates featured articles section structure and global spacing by nesting the “View more” button within the featured block, adding responsive `.featureArticles` padding, and switching `.section` padding to `clamp()` for better scaling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5958c18a3f4988d59dd104218d67f0da11b0e765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->